### PR TITLE
[PKG-1668] nss 3.89.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ source:
 
 build:
   number: 0
-  # nss and its dependency nspr aren't currently available on s390x
-  skip: true  # [win or s390x]
+  skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('nss', max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.89" %}
+{% set version = "3.89.1" %}
 {% set version_us = version.replace(".", "_") %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://ftp.mozilla.org/pub/security/nss/releases/NSS_{{ version_us }}_RTM/src/nss-{{ version }}.tar.gz
-  sha256: 55c37a3f4da010d0574fb8b39264cb1e7b4ce9e6c2954c1c7ecf9f41ee00bed5
+  sha256: 3adaedb9e70c3c5f40603bf60a01e336190a6dbe01929d395f16b01fe84a0156
   patches:
     # Adds auto-generated nss.pc and nss-config script, and allows building without nspr in the source tree 
     - nss-3.55-standalone-1.patch
@@ -35,7 +35,7 @@ requirements:
     - patch
     - sysroot_linux-64 2.17  # [linux64]
   host:
-    - nspr 4.33
+    - nspr 4.35
     - sqlite 3.41.2
     - zlib 1.2.13
 


### PR DESCRIPTION
Updating because `nss` **<3.87** is impacted by CVE-2022-3479 with a score of 7.5

Source code: https://hg.mozilla.org/projects/nss/file/NSS_3_89_BRANCH
Requirements: https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building

Actions:
1. Do not skip `s390x` as `nspr 4.35` will be available on this platform https://github.com/AnacondaRecipes/nspr-feedstock/pull/2
2. Add `host` pinnings
3. Remove `unix` selector from tests as we do not build on `win` and to satisfy the linter
4. Update home and doc urls

Notes:
- `nss 3.89.1` requires new functionality from `nspr 4.35` https://github.com/AnacondaRecipes/nspr-feedstock/pull/2